### PR TITLE
bugfix: use ScrollView as parent (Android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ function CityPicker() {
 ## Memoization
 
 The individual items in the picker (`<WheelPickerItem />`) are [strictly memoized](https://github.com/erksch/react-native-wheely/blob/master/src/WheelPickerItem.tsx#L109-L114), meaning that they will not rerender after the initial render. Rerendering the picker items uncontrollably would lead to bad performance with large number of options. Item styles, animation functions and other parameters of items therefore must be static and changes to them after the initial render will have no effect.
+
+
+## ScrollView
+If you need to use this component inside another scrollView, we suggest to use the scrollView imported from `react-native-gesture-handler`, and also you must turn on the `nestedScrollEnabled` property of your scrollView (for Android devices).

--- a/src/WheelPicker.tsx
+++ b/src/WheelPicker.tsx
@@ -131,6 +131,7 @@ const WheelPicker: React.FC<Props> = ({
       <Animated.FlatList<string | null>
         {...flatListProps}
         ref={flatListRef}
+        nestedScrollEnabled
         style={styles.scrollView}
         showsVerticalScrollIndicator={false}
         onScroll={Animated.event(


### PR DESCRIPTION
- Add support for Android device to use this component inside another scrollView

It's forbidden (not recommended) from react-native platform to use the FlatList inside another ScrollView component, but if it's necessary we can do it using a property named `nestedScrollEnabled`, the default value for this property is true in iOS platform, but you have to turn it on in Android if it's necessary. please check the link below for more information. 

https://github.com/facebook/react-native/issues/21436